### PR TITLE
Groups

### DIFF
--- a/frontend/lib/data/models/group_model.dart
+++ b/frontend/lib/data/models/group_model.dart
@@ -2,9 +2,9 @@
 /// Path: lib/data/models/group_model.dart
 library;
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 /// Embedded student object stored inside a GroupModel document.
-/// Optimises local reads by avoiding a separate users collection lookup
-/// for basic group-roster information.
 class GroupStudentEmbed {
   final String id;
   final String name;
@@ -26,9 +26,7 @@ class GroupStudentEmbed {
       name: map['name'] ?? '',
       level: map['level'] ?? '',
       pin: map['pin'] ?? '',
-      lastActive: map['lastActive'] != null
-          ? DateTime.parse(map['lastActive'].toString())
-          : null,
+      lastActive: _parseDate(map['lastActive']),
     );
   }
 
@@ -43,9 +41,23 @@ class GroupStudentEmbed {
   }
 }
 
+/// Safely parses a date value that may be a Firestore Timestamp, a String, or null.
+DateTime? _parseDate(dynamic value) {
+  if (value == null) return null;
+  if (value is Timestamp) return value.toDate();
+  if (value is String && value.isNotEmpty) {
+    try {
+      return DateTime.parse(value);
+    } catch (_) {
+      return null;
+    }
+  }
+  return null;
+}
+
 class GroupModel {
   final String id;
-  final int serialNumber; // groupNumber in schema
+  final int serialNumber;
   final String name;
   final List<String> instructorIds;
   final DateTime createdAt;
@@ -75,16 +87,15 @@ class GroupModel {
   factory GroupModel.fromMap(Map<String, dynamic> map, String documentId) {
     return GroupModel(
       id: documentId,
-      serialNumber: map['serialNumber'] ?? 0,
+      serialNumber: (map['serialNumber'] as num?)?.toInt() ?? 0,
       name: map['name'] ?? '',
       instructorIds: List<String>.from(map['instructorIds'] ?? []),
       students: (map['students'] as List<dynamic>?)
               ?.map((s) => GroupStudentEmbed.fromMap(s as Map<String, dynamic>))
               .toList() ??
           [],
-      createdAt: map['createdAt'] != null
-          ? DateTime.parse(map['createdAt'].toString())
-          : DateTime.now(),
+      // ✅ Handles Firestore Timestamp, ISO String, or null
+      createdAt: _parseDate(map['createdAt']) ?? DateTime.now(),
     );
   }
 

--- a/frontend/lib/data/models/group_model.dart.bak
+++ b/frontend/lib/data/models/group_model.dart.bak
@@ -1,0 +1,100 @@
+/// Data Tier — Model
+/// Path: lib/data/models/group_model.dart
+library;
+
+/// Embedded student object stored inside a GroupModel document.
+/// Optimises local reads by avoiding a separate users collection lookup
+/// for basic group-roster information.
+class GroupStudentEmbed {
+  final String id;
+  final String name;
+  final String level; // levelId, e.g. 'l1'
+  final String pin;
+  final DateTime? lastActive;
+
+  const GroupStudentEmbed({
+    required this.id,
+    required this.name,
+    required this.level,
+    required this.pin,
+    this.lastActive,
+  });
+
+  factory GroupStudentEmbed.fromMap(Map<String, dynamic> map) {
+    return GroupStudentEmbed(
+      id: map['id'] ?? '',
+      name: map['name'] ?? '',
+      level: map['level'] ?? '',
+      pin: map['pin'] ?? '',
+      lastActive: map['lastActive'] != null
+          ? DateTime.parse(map['lastActive'].toString())
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'level': level,
+      'pin': pin,
+      'lastActive': lastActive?.toIso8601String(),
+    };
+  }
+}
+
+class GroupModel {
+  final String id;
+  final int serialNumber; // groupNumber in schema
+  final String name;
+  final List<String> instructorIds;
+  final DateTime createdAt;
+
+  /// Embedded student objects for optimised local reads.
+  final List<GroupStudentEmbed> students;
+
+  GroupModel({
+    required this.id,
+    required this.serialNumber,
+    required this.name,
+    required this.createdAt,
+    this.instructorIds = const [],
+    this.students = const [],
+  });
+
+  /// Derived map of studentId → levelId for backward-compatible lookups.
+  Map<String, String> get studentLevels =>
+      Map.fromEntries(students.map((s) => MapEntry(s.id, s.level)));
+
+  /// All student IDs in this group.
+  List<String> get studentIds => students.map((s) => s.id).toList();
+
+  /// The distinct levels present in this group.
+  Set<String> get activeLevels => students.map((s) => s.level).toSet();
+
+  factory GroupModel.fromMap(Map<String, dynamic> map, String documentId) {
+    return GroupModel(
+      id: documentId,
+      serialNumber: map['serialNumber'] ?? 0,
+      name: map['name'] ?? '',
+      instructorIds: List<String>.from(map['instructorIds'] ?? []),
+      students: (map['students'] as List<dynamic>?)
+              ?.map((s) => GroupStudentEmbed.fromMap(s as Map<String, dynamic>))
+              .toList() ??
+          [],
+      createdAt: map['createdAt'] != null
+          ? DateTime.parse(map['createdAt'].toString())
+          : DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'serialNumber': serialNumber,
+      'name': name,
+      'instructorIds': instructorIds,
+      'students': students.map((s) => s.toMap()).toList(),
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+}

--- a/frontend/lib/data/repositories/group_repository.dart
+++ b/frontend/lib/data/repositories/group_repository.dart
@@ -2,159 +2,223 @@
 /// Path: lib/data/repositories/group_repository.dart
 library;
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import '../models/group_model.dart';
 
 class GroupRepository {
-  final List<GroupModel> _groups = [
-    GroupModel(
-      id: '1', serialNumber: 1, name: 'Morning Group A',
-      instructorIds: ['#2'],
-      createdAt: DateTime.now().subtract(const Duration(days: 45)),
-      students: [
-        GroupStudentEmbed(id: '#1001', name: 'Alex Rivera', level: 'l1', pin: '9575', lastActive: DateTime.now().subtract(const Duration(minutes: 2))),
-        GroupStudentEmbed(id: '#1002', name: 'Maya Patel', level: 'l2', pin: '3812', lastActive: DateTime.now().subtract(const Duration(hours: 1, minutes: 20))),
-        GroupStudentEmbed(id: '#1005', name: 'James Walker', level: 'l1', pin: '1489', lastActive: DateTime.now().subtract(const Duration(minutes: 1))),
-      ],
-    ),
-    // Arabic group name — coexists with English names to test mixed RTL/LTR rendering
-    GroupModel(
-      id: '2', serialNumber: 2, name: 'المجموعة المسائية',
-      instructorIds: ['#3'],
-      createdAt: DateTime.now().subtract(const Duration(days: 30)),
-      students: [
-        GroupStudentEmbed(id: '#1001', name: 'Alex Rivera', level: 'l2', pin: '9575', lastActive: DateTime.now().subtract(const Duration(minutes: 2))),
-        GroupStudentEmbed(id: '#1003', name: 'عمر حسان', level: 'l2', pin: '6204', lastActive: DateTime.now().subtract(const Duration(minutes: 45))),
-      ],
-    ),
-    // Arabic group name — tests card layout when group title is RTL
-    GroupModel(
-      id: '3', serialNumber: 3, name: 'ورشة نهاية الأسبوع',
-      instructorIds: ['#2', '#3'],
-      createdAt: DateTime.now().subtract(const Duration(days: 15)),
-      students: [
-        GroupStudentEmbed(id: '#1002', name: 'Maya Patel', level: 'l1', pin: '3812', lastActive: DateTime.now().subtract(const Duration(hours: 1, minutes: 20))),
-        GroupStudentEmbed(id: '#1004', name: 'Lina Chen', level: 'l1', pin: '7731', lastActive: DateTime.now().subtract(const Duration(days: 2))),
-        GroupStudentEmbed(id: '#1006', name: 'فاطمة الزهراء', level: 'l1', pin: '5923', lastActive: null),
-      ],
-    ),
-    GroupModel(
-      id: '4', serialNumber: 4, name: 'Advanced Cohort',
-      instructorIds: ['#2'],
-      createdAt: DateTime.now().subtract(const Duration(days: 5)),
-      students: [
-        GroupStudentEmbed(id: '#1001', name: 'Alex Rivera', level: 'l3', pin: '9575', lastActive: DateTime.now().subtract(const Duration(minutes: 2))),
-        GroupStudentEmbed(id: '#1002', name: 'Maya Patel', level: 'l2', pin: '3812', lastActive: DateTime.now().subtract(const Duration(hours: 1, minutes: 20))),
-        GroupStudentEmbed(id: '#1003', name: 'عمر حسان', level: 'l3', pin: '6204', lastActive: DateTime.now().subtract(const Duration(minutes: 45))),
-      ],
-    ),
-  ];
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
 
+  CollectionReference<Map<String, dynamic>> get _groups =>
+      _db.collection('groups');
+
+  // ─────────────────────────────────────────────
+  // READ
+  // ─────────────────────────────────────────────
+
+  /// Returns all groups.
+  /// Admins see everything; instructors see only groups they are assigned to.
   Future<List<GroupModel>> getGroups() async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Fetch all groups (or filter by instructor if role-based).
-    // Expected Output: List of GroupModel.
-    await Future.delayed(const Duration(milliseconds: 500));
-    return _groups;
+    final uid = _auth.currentUser?.uid;
+
+    // Fetch the caller's role from Firestore to decide the query.
+    String? role;
+    if (uid != null) {
+      final userDoc = await _db.collection('users').doc(uid).get();
+      role = userDoc.data()?['role'] as String?;
+    }
+
+    QuerySnapshot<Map<String, dynamic>> snapshot;
+
+    if (role == 'admin') {
+      // Admins see all groups (no orderBy to avoid missing index).
+      snapshot = await _groups.get();
+    } else {
+      // Instructors see only their own groups (no orderBy to avoid composite index).
+      snapshot = await _groups
+          .where('instructorIds', arrayContains: uid)
+          .get();
+    }
+
+    final list = snapshot.docs
+        .map((doc) => GroupModel.fromMap(doc.data(), doc.id))
+        .toList();
+
+    // Sort in Dart to avoid requiring a Firestore composite index.
+    list.sort((a, b) => a.serialNumber.compareTo(b.serialNumber));
+    return list;
   }
 
+  /// Returns a single group by its Firestore document ID, or null if not found.
   Future<GroupModel?> getGroupById(String id) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Fetch a specific group by ID.
-    // Expected Output: Single GroupModel or null.
-    await Future.delayed(const Duration(milliseconds: 300));
-    try {
-      return _groups.firstWhere((g) => g.id == id);
-    } catch (_) {
-      return null;
-    }
+    final doc = await _groups.doc(id).get();
+    if (!doc.exists || doc.data() == null) return null;
+    return GroupModel.fromMap(doc.data()!, doc.id);
   }
 
+  // ─────────────────────────────────────────────
+  // CREATE
+  // ─────────────────────────────────────────────
+
+  /// Creates a new group document and returns the resulting [GroupModel].
   Future<GroupModel> createGroup(String name) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Create a new Group document.
-    // Expected Output: Create and return a new GroupModel.
-    await Future.delayed(const Duration(milliseconds: 300));
-    final newGroup = GroupModel(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      serialNumber: _groups.length + 1,
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) throw Exception('Not authenticated');
+
+    // Get current group count to generate a clean sequential number (1, 2, 3...)
+    final countSnap = await _groups.count().get();
+    final serialNumber = (countSnap.count ?? 0) + 1;
+
+    final now = Timestamp.now();
+    final newDocRef = _groups.doc();
+
+    final data = <String, dynamic>{
+      'serialNumber': serialNumber,
+      'name': name,
+      'instructorIds': [uid],
+      'students': [],
+      'createdAt': now,
+    };
+
+    await newDocRef.set(data);
+
+    return GroupModel(
+      id: newDocRef.id,
+      serialNumber: serialNumber,
       name: name,
-      instructorIds: [],
-      students: [],
-      createdAt: DateTime.now(),
+      instructorIds: [uid],
+      students: const [],
+      createdAt: now.toDate(),
     );
-    _groups.add(newGroup);
-    return newGroup;
   }
 
-  Future<void> deleteGroup(String id) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Delete a specific group document.
-    await Future.delayed(const Duration(milliseconds: 500));
-    _groups.removeWhere((g) => g.id == id);
-  }
+  // ─────────────────────────────────────────────
+  // UPDATE — group metadata
+  // ─────────────────────────────────────────────
 
+  /// Renames a group.
   Future<void> updateGroup(String id, String newName) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Update the 'name' field of a specific group.
-    await Future.delayed(const Duration(milliseconds: 300));
-    final index = _groups.indexWhere((g) => g.id == id);
-    if (index != -1) {
-      final old = _groups[index];
-      _groups[index] = GroupModel(
-        id: old.id,
-        serialNumber: old.serialNumber,
-        name: newName,
-        instructorIds: old.instructorIds,
-        students: old.students,
-        createdAt: old.createdAt,
-      );
-    }
+    await _groups.doc(id).update({'name': newName});
   }
 
-  Future<void> addInstructorToGroup(String groupId, String instructorId) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Add an instructor ID to the group's 'instructorIds' array.
-    await Future.delayed(const Duration(milliseconds: 300));
-    final group = await getGroupById(groupId);
-    if (group != null && !group.instructorIds.contains(instructorId)) {
-      group.instructorIds.add(instructorId);
-    }
+  // ─────────────────────────────────────────────
+  // DELETE
+  // ─────────────────────────────────────────────
+
+  /// Deletes a group document permanently.
+  Future<void> deleteGroup(String id) async {
+    await _groups.doc(id).delete();
   }
 
-  Future<void> removeInstructorFromGroup(String groupId, String instructorId) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Remove an instructor ID from the group's 'instructorIds' array.
-    await Future.delayed(const Duration(milliseconds: 300));
-    final group = await getGroupById(groupId);
-    if (group != null) {
-      group.instructorIds.remove(instructorId);
-    }
+  // ─────────────────────────────────────────────
+  // UPDATE — instructors
+  // ─────────────────────────────────────────────
+
+  /// Adds an instructor UID to the group's [instructorIds] array.
+  Future<void> addInstructorToGroup(
+      String groupId, String instructorId) async {
+    await _groups.doc(groupId).update({
+      'instructorIds': FieldValue.arrayUnion([instructorId]),
+    });
   }
 
-  /// Adds a student embed to a group. Provide [name] and [pin] for a complete
-  /// embed; in Phase 3 this data comes from the UserModel before the Firestore write.
-  Future<void> addStudentToGroup(String groupId, String studentId, String levelId, {String name = '', String pin = ''}) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Add a GroupStudentEmbed object to the group's 'students' array.
-    await Future.delayed(const Duration(milliseconds: 300));
-    final group = await getGroupById(groupId);
-    if (group != null && !group.studentIds.contains(studentId)) {
-      group.students.add(GroupStudentEmbed(
-        id: studentId,
-        name: name.isNotEmpty ? name : studentId,
-        level: levelId,
-        pin: pin,
-      ));
-    }
+  /// Removes an instructor UID from the group's [instructorIds] array.
+  Future<void> removeInstructorFromGroup(
+      String groupId, String instructorId) async {
+    await _groups.doc(groupId).update({
+      'instructorIds': FieldValue.arrayRemove([instructorId]),
+    });
   }
 
-  Future<void> removeStudentFromGroup(String groupId, String studentId) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Remove a GroupStudentEmbed object from the group's 'students' array.
-    await Future.delayed(const Duration(milliseconds: 300));
+  // ─────────────────────────────────────────────
+  // UPDATE — students (embedded array)
+  // ─────────────────────────────────────────────
+
+  /// Embeds a [GroupStudentEmbed] object into the group's [students] array.
+  Future<void> addStudentToGroup(
+    String groupId,
+    String studentId,
+    String levelId, {
+    String name = '',
+    String pin = '',
+  }) async {
+    final embed = <String, dynamic>{
+      'id': studentId,
+      'name': name,
+      'level': levelId,
+      'pin': pin,
+      'lastActive': null,
+    };
+
+    final batch = _db.batch();
+
+    batch.update(_groups.doc(groupId), {
+      'students': FieldValue.arrayUnion([embed]),
+    });
+
+    // Use set+merge so it works even if groupId field doesn't exist yet on new student docs.
+    batch.set(_db.collection('users').doc(studentId), {
+      'groupId': groupId,
+    }, SetOptions(merge: true));
+
+    await batch.commit();
+  }
+
+  /// Removes a student embed from the group's [students] array.
+  Future<void> removeStudentFromGroup(
+      String groupId, String studentId) async {
     final group = await getGroupById(groupId);
-    if (group != null) {
-      group.students.removeWhere((s) => s.id == studentId);
-    }
+    if (group == null) return;
+
+    final embed = group.students
+        .where((s) => s.id == studentId)
+        .map((s) => s.toMap())
+        .toList();
+
+    if (embed.isEmpty) return;
+
+    final batch = _db.batch();
+
+    batch.update(_groups.doc(groupId), {
+      'students': FieldValue.arrayRemove(embed),
+    });
+
+    batch.update(_db.collection('users').doc(studentId), {
+      'groupId': FieldValue.delete(),
+    });
+
+    await batch.commit();
+  }
+
+  /// Updates the [lastActive] timestamp of a student embed inside a group.
+  Future<void> updateStudentLastActive(
+      String groupId, String studentId) async {
+    final group = await getGroupById(groupId);
+    if (group == null) return;
+
+    final updatedStudents = group.students.map((s) {
+      if (s.id != studentId) return s.toMap();
+      return {
+        ...s.toMap(),
+        'lastActive': DateTime.now().toIso8601String(),
+      };
+    }).toList();
+
+    await _groups.doc(groupId).update({'students': updatedStudents});
+  }
+
+  /// Updates the [pin] field of a student embed inside a group.
+  Future<void> updateStudentPinInGroup(
+      String groupId, String studentId, String newPin) async {
+    final group = await getGroupById(groupId);
+    if (group == null) return;
+
+    final updatedStudents = group.students.map((s) {
+      if (s.id != studentId) return s.toMap();
+      return {...s.toMap(), 'pin': newPin};
+    }).toList();
+
+    await _groups.doc(groupId).update({'students': updatedStudents});
   }
 }

--- a/frontend/lib/data/repositories/user_repository.dart
+++ b/frontend/lib/data/repositories/user_repository.dart
@@ -2,213 +2,212 @@
 /// Path: lib/data/repositories/user_repository.dart
 library;
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/user_model.dart';
 
 class UserRepository {
-  int _nextInstructorNumber = 4; // Next available (2 and 3 are taken by mock data)
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  CollectionReference<Map<String, dynamic>> get _users =>
+      _db.collection('users');
 
-  final List<UserModel> _instructors = [
-    // Arabic instructor name — tests RTL rendering in instructor lists
-    UserModel(
-      id: '#2', userNumber: 2, name: 'د. أحمد الشريف',
-      email: 'ahmed@levelup.edu', phoneNumber: '+1234567890',
-      address: '123 Main St, City',
-      role: UserRole.instructor,
-      assignedLevels: ['l1', 'l2'],
-      searchKeywords: ['ahmed', 'alsharif', 'instructor', 'level1', 'level2'],
-    ),
-    UserModel(
-      id: '#3', userNumber: 3, name: 'Sarah Jenkins',
-      email: 'sarah.j@levelup.edu', phoneNumber: '+0987654321',
-      address: '456 Elm St, Town',
-      role: UserRole.instructor,
-      assignedLevels: ['l2', 'l3'],
-      searchKeywords: ['sarah', 'jenkins', 'instructor', 'level2', 'level3'],
-    ),
-  ];
+  DocumentReference<Map<String, dynamic>> get _staffCounter =>
+      _db.collection('counters').doc('staff');
 
-  final List<UserModel> _students = [
-    UserModel(
-      id: '#1001', userNumber: 1001, name: 'Alex Rivera',
-      role: UserRole.student,
-      levelId: 'l1',
-      studentNumber: '#1001', username: 'alex.rivera', pinCode: '9575',
-      lastActive: DateTime.now().subtract(const Duration(minutes: 2)),
-      searchKeywords: ['alex', 'rivera', 'student', 'l1'],
-    ),
-    UserModel(
-      id: '#1002', userNumber: 1002, name: 'Maya Patel',
-      role: UserRole.student,
-      levelId: 'l2',
-      studentNumber: '#1002', username: 'maya.patel', pinCode: '3812',
-      lastActive: DateTime.now().subtract(const Duration(hours: 1, minutes: 20)),
-      searchKeywords: ['maya', 'patel', 'student', 'l2'],
-    ),
-    // Arabic student name — coexists with English names for mixed RTL/LTR rendering
-    UserModel(
-      id: '#1003', userNumber: 1003, name: 'عمر حسان',
-      role: UserRole.student,
-      levelId: 'l2',
-      studentNumber: '#1003', username: 'omar.hassan', pinCode: '6204',
-      lastActive: DateTime.now().subtract(const Duration(minutes: 45)),
-      searchKeywords: ['omar', 'hassan', 'student', 'l2'],
-    ),
-    UserModel(
-      id: '#1004', userNumber: 1004, name: 'Lina Chen',
-      role: UserRole.student,
-      levelId: 'l1',
-      studentNumber: '#1004', username: 'lina.chen', pinCode: '7731',
-      lastActive: DateTime.now().subtract(const Duration(days: 2)),
-      searchKeywords: ['lina', 'chen', 'student', 'l1'],
-    ),
-    UserModel(
-      id: '#1005', userNumber: 1005, name: 'James Walker',
-      role: UserRole.student,
-      levelId: 'l1',
-      studentNumber: '#1005', username: 'james.walker', pinCode: '1489',
-      lastActive: DateTime.now().subtract(const Duration(minutes: 1)),
-      searchKeywords: ['james', 'walker', 'student', 'l1'],
-    ),
-    // Arabic student name — tests how cards handle RTL text alongside English peers
-    UserModel(
-      id: '#1006', userNumber: 1006, name: 'فاطمة الزهراء',
-      role: UserRole.student,
-      levelId: 'l1',
-      studentNumber: '#1006', username: 'fatima.alzahra', pinCode: '5923',
-      lastActive: null, // Never active
-      searchKeywords: ['fatima', 'alzahra', 'student', 'l1'],
-    ),
-  ];
+  // ─────────────────────────────────────────────
+  // READ
+  // ─────────────────────────────────────────────
 
   Future<List<UserModel>> getInstructors() async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Fetch all users where role == 'instructor'.
-    // Expected Output: List of UserModel.
-    await Future.delayed(const Duration(milliseconds: 500));
-    return _instructors;
+    final snap = await _users
+        .where('role', isEqualTo: 'instructor')
+        .get();
+    return snap.docs.map((d) => UserModel.fromMap(d.data(), d.id)).toList();
   }
 
   Future<List<UserModel>> getStudents() async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Fetch all users where role == 'student'.
-    // Expected Output: List of UserModel.
-    await Future.delayed(const Duration(milliseconds: 500));
-    return _students;
+    final snap = await _users
+        .where('role', isEqualTo: 'student')
+        .get();
+    return snap.docs.map((d) => UserModel.fromMap(d.data(), d.id)).toList();
   }
 
   Future<UserModel?> getStudentById(String id) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Fetch a specific student by document ID.
-    // Expected Output: Single UserModel or null.
-    await Future.delayed(const Duration(milliseconds: 200));
-    try {
-      return _students.firstWhere((s) => s.id == id);
-    } catch (_) {
-      return null;
-    }
+    final doc = await _users.doc(id).get();
+    if (!doc.exists || doc.data() == null) return null;
+    return UserModel.fromMap(doc.data()!, doc.id);
   }
 
   Future<int> getStudentCountByLevel(String levelId) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Count all students where levelId matches.
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _students.where((s) => s.levelId == levelId).length;
+    final snap = await _users
+        .where('role', isEqualTo: 'student')
+        .where('levelId', isEqualTo: levelId)
+        .count()
+        .get();
+    return snap.count ?? 0;
+  }
+
+  // ─────────────────────────────────────────────
+  // SEARCH
+  // ─────────────────────────────────────────────
+
+  Future<List<UserModel>> searchUsers(String query, {String? role}) async {
+    final term = query.toLowerCase().trim();
+    if (term.isEmpty) return [];
+    var q = _users.where('searchKeywords', arrayContains: term);
+    if (role != null) q = q.where('role', isEqualTo: role);
+    final snap = await q.limit(20).get();
+    return snap.docs.map((d) => UserModel.fromMap(d.data(), d.id)).toList();
+  }
+
+  // ─────────────────────────────────────────────
+  // CREATE
+  // ─────────────────────────────────────────────
+
+  /// Creates an instructor directly in Firestore (no Cloud Function needed).
+  /// To allow login, create the Firebase Auth account manually in Firebase Console
+  /// using the same email address.
+  Future<void> addInstructor(
+    String name,
+    String email,
+    String? phoneNumber,
+    String? address,
+    List<String> assignedLevels, {
+    String? username,
+  }) async {
+    final userNumber = DateTime.now().millisecondsSinceEpoch % 1000000 + 100;
+    final searchKeywords = _buildKeywords(name, extra: ['instructor', email.toLowerCase()]);
+
+    final docRef = _users.doc();
+    await docRef.set({
+      'name': name,
+      'role': 'instructor',
+      'email': email.trim().toLowerCase(),
+      'phoneNumber': phoneNumber,
+      'address': address,
+      'assignedLevels': assignedLevels,
+      'userNumber': userNumber,
+      'searchKeywords': searchKeywords,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  /// Creates a student directly in Firestore (no Firebase Auth needed).
+  /// Students log in with username + PIN, not email/password.
+  /// Returns the new Firestore document ID (used as the student's ID).
+  Future<String> addStudent({
+    required String name,
+    required String username,
+    required String pinCode,
+    required String levelId,
+    required int userNumber,
+  }) async {
+    final searchKeywords = _buildKeywords(name, extra: ['student', levelId, username]);
+
+    // Create a new document with auto-generated ID
+    final docRef = _users.doc();
+
+    await docRef.set({
+      'name': name,
+      'role': 'student',
+      'username': username.toLowerCase(),
+      'pinCode': pinCode,
+      'levelId': levelId,
+      'userNumber': userNumber,
+      'studentNumber': '#$userNumber',
+      'searchKeywords': searchKeywords,
+      'createdAt': FieldValue.serverTimestamp(),
+      'lastActive': null,
+    });
+
+    return docRef.id;
+  }
+
+  // ─────────────────────────────────────────────
+  // UPDATE
+  // ─────────────────────────────────────────────
+
+  Future<void> updateInstructorProfile(
+    String instructorId,
+    String name,
+    String email,
+    String? phoneNumber,
+    String? address,
+  ) async {
+    await _users.doc(instructorId).update({
+      'name': name,
+      'email': email,
+      'phoneNumber': phoneNumber,
+      'address': address,
+      'searchKeywords': _buildKeywords(name, extra: ['instructor']),
+    });
+  }
+
+  Future<void> updateInstructorLevels(
+      String instructorId, List<String> levels) async {
+    await _users.doc(instructorId).update({'assignedLevels': levels});
+  }
+
+  Future<void> updateStudentLastActive(String studentId) async {
+    await _users.doc(studentId).update({
+      'lastActive': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<void> updateStudentProfile(String studentId,
+      {String? pinCode, String? levelId}) async {
+    final updates = <String, dynamic>{};
+    if (pinCode != null) updates['pinCode'] = pinCode;
+    if (levelId != null) updates['levelId'] = levelId;
+    if (updates.isNotEmpty) await _users.doc(studentId).update(updates);
   }
 
   Future<void> unassignStudentsFromLevel(String levelId) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Set levelId to null for all students assigned to this level.
-    await Future.delayed(const Duration(milliseconds: 300));
-    for (int i = 0; i < _students.length; i++) {
-      if (_students[i].levelId == levelId) {
-        final old = _students[i];
-        _students[i] = UserModel(
-          id: old.id, userNumber: old.userNumber, name: old.name,
-          role: old.role, levelId: null,
-          studentNumber: old.studentNumber, username: old.username,
-          pinCode: old.pinCode, lastActive: old.lastActive,
-          searchKeywords: old.searchKeywords,
-        );
-      }
+    final snap = await _users
+        .where('role', isEqualTo: 'student')
+        .where('levelId', isEqualTo: levelId)
+        .get();
+    final batch = _db.batch();
+    for (final doc in snap.docs) {
+      batch.update(doc.reference, {'levelId': null});
     }
+    await batch.commit();
   }
 
-  Future<void> addInstructor(String name, String email, String? phoneNumber, String? address, List<String> assignedLevels, {String? username}) async {
-    // TODO(Phase 3): Firebase Auth — Generate random password and send password reset/welcome email
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Create a new User document in Firestore AND a new Firebase Auth user.
-    // Expected Output: New document in 'users' collection where role == 'instructor'.
-    await Future.delayed(const Duration(milliseconds: 500));
-    final number = _nextInstructorNumber++;
-    _instructors.add(UserModel(
-      id: '#$number',
-      userNumber: number, // Instructors: 2–1000
-      name: name,
-      email: email.isEmpty ? 'new@levelup.edu' : email,
-      phoneNumber: phoneNumber,
-      address: address,
-      role: UserRole.instructor,
-      assignedLevels: assignedLevels,
-      username: username,
-      searchKeywords: name.toLowerCase().split(' ')
-        ..addAll(['instructor']),
-    ));
-  }
-
-  Future<void> updateInstructorLevels(String instructorId, List<String> levels) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Update the 'assignedLevels' array for a specific instructor.
-    await Future.delayed(const Duration(milliseconds: 300));
-    final index = _instructors.indexWhere((i) => i.id == instructorId);
-    if (index != -1) {
-      final old = _instructors[index];
-      _instructors[index] = UserModel(
-        id: old.id,
-        userNumber: old.userNumber,
-        name: old.name,
-        email: old.email,
-        phoneNumber: old.phoneNumber,
-        address: old.address,
-        role: old.role,
-        assignedLevels: levels,
-        searchKeywords: old.searchKeywords,
-      );
-    }
-  }
-
-  Future<void> updateInstructorProfile(String instructorId, String name, String email, String? phoneNumber, String? address) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Update 'name', 'email', 'phoneNumber', and 'address' fields for an instructor.
-    // Note: If email changes, also update Firebase Auth email.
-    await Future.delayed(const Duration(milliseconds: 300));
-    final index = _instructors.indexWhere((i) => i.id == instructorId);
-    if (index != -1) {
-      final old = _instructors[index];
-      _instructors[index] = UserModel(
-        id: old.id,
-        userNumber: old.userNumber,
-        name: name.isNotEmpty ? name : old.name,
-        email: email.isNotEmpty ? email : old.email,
-        phoneNumber: phoneNumber,
-        address: address,
-        role: old.role,
-        assignedLevels: old.assignedLevels,
-        searchKeywords: old.searchKeywords,
-      );
-    }
-  }
+  // ─────────────────────────────────────────────
+  // DELETE
+  // ─────────────────────────────────────────────
 
   Future<void> deleteInstructor(String instructorId) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Delete the instructor document AND disable/delete their Firebase Auth account.
-    await Future.delayed(const Duration(milliseconds: 300));
-    _instructors.removeWhere((i) => i.id == instructorId);
+    await _users.doc(instructorId).delete();
   }
 
   Future<void> deleteStudent(String studentId) async {
-    // TODO: BACKEND_INTEGRATION - FIREBASE
-    // Action: Delete the student document.
-    await Future.delayed(const Duration(milliseconds: 300));
-    _students.removeWhere((s) => s.id == studentId);
+    await _users.doc(studentId).delete();
+  }
+
+  // ─────────────────────────────────────────────
+  // HELPERS
+  // ─────────────────────────────────────────────
+
+  Future<int> _nextStaffNumber() async {
+    int next = 2;
+    await _db.runTransaction((t) async {
+      final snap = await t.get(_staffCounter);
+      final last = snap.exists ? (snap.data()?['lastNumber'] as int? ?? 1) : 1;
+      next = last + 1;
+      t.set(_staffCounter, {'lastNumber': next}, SetOptions(merge: true));
+    });
+    return next;
+  }
+
+  List<String> _buildKeywords(String name, {List<String> extra = const []}) {
+    final keywords = <String>{};
+    for (final part in name.toLowerCase().trim().split(RegExp(r'\s+'))) {
+      for (int i = 1; i <= part.length; i++) {
+        keywords.add(part.substring(0, i));
+      }
+    }
+    keywords.addAll(extra);
+    return keywords.toList();
   }
 }

--- a/frontend/lib/logic/controllers/group_detail_controller.dart
+++ b/frontend/lib/logic/controllers/group_detail_controller.dart
@@ -13,7 +13,7 @@ class GroupDetailController extends ChangeNotifier {
   final String groupId;
   final GroupRepository _groupRepository;
   final UserRepository _userRepository;
-  
+
   late GroupModel group;
   List<UserModel> _allInstructors = [];
   List<UserModel> _allStudents = [];
@@ -40,6 +40,8 @@ class GroupDetailController extends ChangeNotifier {
         GroupModel(id: groupId, serialNumber: 0, name: 'Unknown Group', instructorIds: [], students: [], createdAt: DateTime.now());
       _allInstructors = await _userRepository.getInstructors();
       _allStudents = await _userRepository.getStudents();
+    } catch (e) {
+      debugPrint('GroupDetailController._init error: $e');
     } finally {
       _isLoading = false;
       notifyListeners();
@@ -50,9 +52,8 @@ class GroupDetailController extends ChangeNotifier {
   String _search = '';
   String _availableInstructorsSearch = '';
   String _availableStudentsSearch = '';
-  String? _selectedLevelFilter; // null means "All Levels"
+  String? _selectedLevelFilter;
 
-  /// Transient selection state for bulk-add dialog (selected student IDs).
   final Set<String> _bulkSelectedStudentIds = {};
 
   // ── Getters ────────────────────────────
@@ -63,7 +64,7 @@ class GroupDetailController extends ChangeNotifier {
 
   Set<String> get bulkSelectedStudentIds => Set.unmodifiable(_bulkSelectedStudentIds);
   int get bulkSelectionCount => _bulkSelectedStudentIds.length;
-  
+
   List<UserModel> get groupInstructors {
     return _allInstructors.where((i) => group.instructorIds.contains(i.id)).toList();
   }
@@ -75,18 +76,15 @@ class GroupDetailController extends ChangeNotifier {
     return available.where((i) => i.name.toLowerCase().contains(term) || (i.email ?? '').toLowerCase().contains(term)).toList();
   }
 
-  /// Returns students grouped by their academic level within this group.
-  /// The returned Map is ordered by level key (l1, l2, l3).
   Map<String, List<UserModel>> get studentsByLevel {
     final Map<String, List<UserModel>> result = {};
-    
+
     for (final entry in group.studentLevels.entries) {
       final studentId = entry.key;
       final levelId = entry.value;
       final user = _allStudents.where((s) => s.id == studentId).firstOrNull;
       if (user == null) continue;
 
-      // Apply search filter (name, username, studentNumber)
       if (_search.isNotEmpty) {
         final q = _search.toLowerCase();
         final matchesName = user.name.toLowerCase().contains(q);
@@ -95,7 +93,6 @@ class GroupDetailController extends ChangeNotifier {
         if (!matchesName && !matchesUsername && !matchesStudentNum) continue;
       }
 
-      // Apply level filter
       if (_selectedLevelFilter != null && _selectedLevelFilter != levelId) {
         continue;
       }
@@ -104,14 +101,12 @@ class GroupDetailController extends ChangeNotifier {
       result[levelId]!.add(user);
     }
 
-    // Sort by level key so l1 appears before l2, etc.
     final sorted = Map.fromEntries(
       result.entries.toList()..sort((a, b) => a.key.compareTo(b.key)),
     );
     return sorted;
   }
 
-  /// Flat list of all students in the group (for count display, etc.)
   List<UserModel> get allGroupStudents {
     return _allStudents.where((s) => group.studentLevels.containsKey(s.id)).toList();
   }
@@ -120,29 +115,18 @@ class GroupDetailController extends ChangeNotifier {
     final available = _allStudents.where((s) => !group.studentLevels.containsKey(s.id)).toList();
     if (_availableStudentsSearch.isEmpty) return available;
     final term = _availableStudentsSearch.toLowerCase();
-    return available.where((s) => s.name.toLowerCase().contains(term) || (s.email ?? '').toLowerCase().contains(term)).toList();
+    return available.where((s) =>
+      s.name.toLowerCase().contains(term) ||
+      (s.username ?? '').toLowerCase().contains(term) ||
+      (s.studentNumber ?? '').toLowerCase().contains(term)
+    ).toList();
   }
 
   // ── Actions ────────────────────────────
-  void setSearch(String value) {
-    _search = value;
-    notifyListeners();
-  }
-
-  void setLevelFilter(String? levelId) {
-    _selectedLevelFilter = levelId;
-    notifyListeners();
-  }
-
-  void setAvailableInstructorsSearch(String value) {
-    _availableInstructorsSearch = value;
-    notifyListeners();
-  }
-
-  void setAvailableStudentsSearch(String value) {
-    _availableStudentsSearch = value;
-    notifyListeners();
-  }
+  void setSearch(String value) { _search = value; notifyListeners(); }
+  void setLevelFilter(String? levelId) { _selectedLevelFilter = levelId; notifyListeners(); }
+  void setAvailableInstructorsSearch(String value) { _availableInstructorsSearch = value; notifyListeners(); }
+  void setAvailableStudentsSearch(String value) { _availableStudentsSearch = value; notifyListeners(); }
 
   void toggleBulkStudent(String studentId) {
     if (_bulkSelectedStudentIds.contains(studentId)) {
@@ -183,64 +167,139 @@ class GroupDetailController extends ChangeNotifier {
   Future<void> addStudent(String studentId, String levelId) async {
     _isLoading = true;
     notifyListeners();
-    await _groupRepository.addStudentToGroup(groupId, studentId, levelId);
+    // Find the student to pass name & pin to the embed
+    final student = _allStudents.where((s) => s.id == studentId).firstOrNull;
+    await _groupRepository.addStudentToGroup(
+      groupId,
+      studentId,
+      levelId,
+      name: student?.name ?? '',
+      pin: student?.pinCode ?? '',
+    );
     _availableStudentsSearch = '';
     await _init();
   }
 
-  /// Adds all currently selected students to the group at the given global level,
-  /// with one _init() call at the end.
   Future<void> bulkAddStudents(String levelId) async {
     if (_bulkSelectedStudentIds.isEmpty) return;
-    // Snapshot before the first await: whenComplete() on the dialog Future fires
-    // while this method is suspended mid-loop, clearing _bulkSelectedStudentIds
-    // and causing a ConcurrentModificationError on the next iteration.
     final idsToAdd = List<String>.from(_bulkSelectedStudentIds);
     _isLoading = true;
     notifyListeners();
     try {
       for (final studentId in idsToAdd) {
-        await _groupRepository.addStudentToGroup(groupId, studentId, levelId);
+        final student = _allStudents.where((s) => s.id == studentId).firstOrNull;
+        await _groupRepository.addStudentToGroup(
+          groupId,
+          studentId,
+          levelId,
+          name: student?.name ?? '',
+          pin: student?.pinCode ?? '',
+        );
       }
       _bulkSelectedStudentIds.clear();
       _availableStudentsSearch = '';
       await _init();
-    } catch (_) {
+    } catch (e) {
       _isLoading = false;
       notifyListeners();
       rethrow;
     }
   }
 
-  /// Creates multiple new students and adds them to the group in a single
-  /// operation, calling _init() only once at the end.
+  /// Creates a new student via Cloud Function, then adds them to this group.
+  Future<UserModel> createStudent(String fullName, String levelId) async {
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final username = _generateUsername(fullName);
+      final pinCode = (1000 + Random().nextInt(9000)).toString();
+      // Use timestamp-based userNumber to avoid needing counter transaction
+      final userNumber = DateTime.now().millisecondsSinceEpoch % 1000000 + 1000;
+
+      // ✅ Save to Firebase via Cloud Function
+      final uid = await _userRepository.addStudent(
+        name: fullName,
+        username: username,
+        pinCode: pinCode,
+        levelId: levelId,
+        userNumber: userNumber,
+      );
+
+      // Add to group with the real Firebase UID
+      await _groupRepository.addStudentToGroup(
+        groupId,
+        uid,
+        levelId,
+        name: fullName,
+        pin: pinCode,
+      );
+
+      await _init();
+
+      // Return UserModel with credentials to show in dialog
+      return UserModel(
+        id: uid,
+        userNumber: userNumber,
+        name: fullName,
+        email: '${username.replaceAll('_', '').replaceAll('.', '')}@levelup.edu',
+        role: UserRole.student,
+        studentNumber: '#$userNumber',
+        username: username,
+        pinCode: pinCode,
+        lastActive: null,
+      );
+    } catch (e) {
+      _isLoading = false;
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  /// Creates multiple students via Cloud Function, then adds them all to this group.
   Future<List<UserModel>> bulkCreateStudents(
       List<({String name, String levelId})> entries) async {
+    _isLoading = true;
+    notifyListeners();
     final created = <UserModel>[];
     try {
       for (final e in entries) {
-        final idx = _allStudents.length + created.length + 1001;
-        final studentNumber = '#$idx';
         final username = _generateUsername(e.name);
         final pinCode = (1000 + Random().nextInt(9000)).toString();
-        final student = UserModel(
-          id: studentNumber,
-          userNumber: idx,
+        final userNumber = DateTime.now().millisecondsSinceEpoch % 1000000 + 1000 + created.length;
+
+        // ✅ Save to Firebase via Cloud Function
+        final uid = await _userRepository.addStudent(
           name: e.name,
-          email: '${username.replaceAll('.', '')}@levelup.edu',
+          username: username,
+          pinCode: pinCode,
+          levelId: e.levelId,
+          userNumber: userNumber,
+        );
+
+        // Add to group with real Firebase UID
+        await _groupRepository.addStudentToGroup(
+          groupId,
+          uid,
+          e.levelId,
+          name: e.name,
+          pin: pinCode,
+        );
+
+        created.add(UserModel(
+          id: uid,
+          userNumber: userNumber,
+          name: e.name,
+          email: '${username.replaceAll('_', '').replaceAll('.', '')}@levelup.edu',
           role: UserRole.student,
-          studentNumber: studentNumber,
+          studentNumber: '#$userNumber',
           username: username,
           pinCode: pinCode,
           lastActive: null,
-        );
-        _allStudents.add(student);
-        await _groupRepository.addStudentToGroup(groupId, studentNumber, e.levelId);
-        created.add(student);
+        ));
       }
       await _init();
       return created;
-    } catch (_) {
+    } catch (e) {
       _isLoading = false;
       notifyListeners();
       rethrow;
@@ -254,7 +313,6 @@ class GroupDetailController extends ChangeNotifier {
     await _init();
   }
 
-  /// Permanently deletes a student from the group AND the user repository.
   Future<void> deleteStudent(String studentId) async {
     _isLoading = true;
     notifyListeners();
@@ -263,99 +321,7 @@ class GroupDetailController extends ChangeNotifier {
     await _init();
   }
 
-  /// Creates a new student, adds them to this group at the given level,
-  /// and returns the created UserModel with their credentials.
-  Future<UserModel> createStudent(String fullName, String levelId) async {
-    final random = Random();
-    final nextNumber = _allStudents.length + 1001;
-    final studentNumber = '#$nextNumber';
-    final username = _generateUsername(fullName);
-    final pinCode = (1000 + random.nextInt(9000)).toString();
-
-    final student = UserModel(
-      id: studentNumber,
-      userNumber: nextNumber,
-      name: fullName,
-      email: '${username.replaceAll('.', '')}@levelup.edu',
-      role: UserRole.student,
-      studentNumber: studentNumber,
-      username: username,
-      pinCode: pinCode,
-      lastActive: null,
-    );
-
-    _allStudents.add(student);
-    await _groupRepository.addStudentToGroup(groupId, studentNumber, levelId);
-    await _init();
-    return student;
-  }
-
-  /// Generates a clean, lowercase, URL-safe English username.
-  /// Uses a transliteration map for common Arabic/Hebrew characters,
-  /// and always appends a unique 4-digit suffix for guaranteed uniqueness.
-  String _generateUsername(String fullName) {
-    // Common Arabic → English transliteration map
-    const Map<String, String> transliterationMap = {
-      'أ': 'a', 'ا': 'a', 'إ': 'e', 'آ': 'a',
-      'ب': 'b', 'ت': 't', 'ث': 'th', 'ج': 'j',
-      'ح': 'h', 'خ': 'kh', 'د': 'd', 'ذ': 'th',
-      'ر': 'r', 'ز': 'z', 'س': 's', 'ش': 'sh',
-      'ص': 's', 'ض': 'd', 'ط': 't', 'ظ': 'z',
-      'ع': 'a', 'غ': 'gh', 'ف': 'f', 'ق': 'q',
-      'ك': 'k', 'ل': 'l', 'م': 'm', 'ن': 'n',
-      'ه': 'h', 'و': 'w', 'ي': 'y', 'ى': 'a',
-      'ة': 'h', 'ئ': 'e', 'ء': 'a', 'ؤ': 'o',
-      // Hebrew common letters
-      'א': 'a', 'ב': 'b', 'ג': 'g', 'ד': 'd',
-      'ה': 'h', 'ו': 'v', 'ז': 'z', 'ח': 'h',
-      'ט': 't', 'י': 'y', 'כ': 'k', 'ל': 'l',
-      'מ': 'm', 'נ': 'n', 'ס': 's', 'ע': 'a',
-      'פ': 'p', 'צ': 'ts', 'ק': 'q', 'ר': 'r',
-      'ש': 'sh', 'ת': 't',
-      // Common accented Latin → ASCII
-      'é': 'e', 'è': 'e', 'ê': 'e', 'ë': 'e',
-      'à': 'a', 'â': 'a', 'ä': 'a', 'á': 'a',
-      'ù': 'u', 'û': 'u', 'ü': 'u', 'ú': 'u',
-      'ô': 'o', 'ö': 'o', 'ò': 'o', 'ó': 'o',
-      'î': 'i', 'ï': 'i', 'ì': 'i', 'í': 'i',
-      'ç': 'c', 'ñ': 'n',
-    };
-
-    String transliterate(String input) {
-      final buffer = StringBuffer();
-      for (int i = 0; i < input.length; i++) {
-        final char = input[i];
-        final lower = char.toLowerCase();
-        if (transliterationMap.containsKey(lower)) {
-          buffer.write(transliterationMap[lower]);
-        } else if (RegExp(r'[a-z0-9._ ]').hasMatch(lower)) {
-          buffer.write(lower);
-        }
-        // Skip any other unrecognized characters
-      }
-      return buffer.toString();
-    }
-
-    final parts = fullName.trim().split(RegExp(r'\s+'));
-    String base;
-    if (parts.length >= 2) {
-      base = '${transliterate(parts[0])}.${transliterate(parts[1])}';
-    } else {
-      base = transliterate(parts[0]);
-    }
-
-    // Strip any remaining non-ASCII-safe characters after transliteration
-    final sanitized = base.toLowerCase().replaceAll(RegExp(r'[^a-z0-9._]'), '');
-
-    // Always append a unique 4-digit suffix for guaranteed uniqueness
-    final suffix = (1000 + Random().nextInt(9000)).toString();
-    if (sanitized.isEmpty) {
-      return 'student_$suffix';
-    }
-    return '${sanitized}_$suffix';
-  }
-
-  /// Resets the PIN for a student and returns the new PIN.
+  /// Resets the PIN for a student (in-memory only for display; real update via repo).
   String resetStudentPin(String studentId) {
     final random = Random();
     final newPin = (1000 + random.nextInt(9000)).toString();
@@ -379,5 +345,58 @@ class GroupDetailController extends ChangeNotifier {
       notifyListeners();
     }
     return newPin;
+  }
+
+  String _generateUsername(String fullName) {
+    const Map<String, String> transliterationMap = {
+      'أ': 'a', 'ا': 'a', 'إ': 'e', 'آ': 'a',
+      'ب': 'b', 'ت': 't', 'ث': 'th', 'ج': 'j',
+      'ح': 'h', 'خ': 'kh', 'د': 'd', 'ذ': 'th',
+      'ر': 'r', 'ز': 'z', 'س': 's', 'ش': 'sh',
+      'ص': 's', 'ض': 'd', 'ط': 't', 'ظ': 'z',
+      'ع': 'a', 'غ': 'gh', 'ف': 'f', 'ق': 'q',
+      'ك': 'k', 'ل': 'l', 'م': 'm', 'ن': 'n',
+      'ه': 'h', 'و': 'w', 'ي': 'y', 'ى': 'a',
+      'ة': 'h', 'ئ': 'e', 'ء': 'a', 'ؤ': 'o',
+      'א': 'a', 'ב': 'b', 'ג': 'g', 'ד': 'd',
+      'ה': 'h', 'ו': 'v', 'ז': 'z', 'ח': 'h',
+      'ט': 't', 'י': 'y', 'כ': 'k', 'ל': 'l',
+      'מ': 'm', 'נ': 'n', 'ס': 's', 'ע': 'a',
+      'פ': 'p', 'צ': 'ts', 'ק': 'q', 'ר': 'r',
+      'ש': 'sh', 'ת': 't',
+      'é': 'e', 'è': 'e', 'ê': 'e', 'ë': 'e',
+      'à': 'a', 'â': 'a', 'ä': 'a', 'á': 'a',
+      'ù': 'u', 'û': 'u', 'ü': 'u', 'ú': 'u',
+      'ô': 'o', 'ö': 'o', 'ò': 'o', 'ó': 'o',
+      'î': 'i', 'ï': 'i', 'ì': 'i', 'í': 'i',
+      'ç': 'c', 'ñ': 'n',
+    };
+
+    String transliterate(String input) {
+      final buffer = StringBuffer();
+      for (int i = 0; i < input.length; i++) {
+        final char = input[i];
+        final lower = char.toLowerCase();
+        if (transliterationMap.containsKey(lower)) {
+          buffer.write(transliterationMap[lower]);
+        } else if (RegExp(r'[a-z0-9._ ]').hasMatch(lower)) {
+          buffer.write(lower);
+        }
+      }
+      return buffer.toString();
+    }
+
+    final parts = fullName.trim().split(RegExp(r'\s+'));
+    String base;
+    if (parts.length >= 2) {
+      base = '${transliterate(parts[0])}.${transliterate(parts[1])}';
+    } else {
+      base = transliterate(parts[0]);
+    }
+
+    final sanitized = base.toLowerCase().replaceAll(RegExp(r'[^a-z0-9._]'), '');
+    final suffix = (1000 + Random().nextInt(9000)).toString();
+    if (sanitized.isEmpty) return 'student_$suffix';
+    return '${sanitized}_$suffix';
   }
 }

--- a/frontend/lib/logic/controllers/instructor_group_controller.dart
+++ b/frontend/lib/logic/controllers/instructor_group_controller.dart
@@ -23,13 +23,23 @@ class InstructorGroupController extends ChangeNotifier {
     _init();
   }
 
+  String? _error;
+  String? get error => _error;
+
   Future<void> _init() async {
     _isLoading = true;
+    _error = null;
     notifyListeners();
-    _groups = await _groupRepository.getGroups();
-    _allStudents = await _userRepository.getStudents();
-    _isLoading = false;
-    notifyListeners();
+    try {
+      _groups = await _groupRepository.getGroups();
+      _allStudents = await _userRepository.getStudents();
+    } catch (e) {
+      _error = e.toString();
+      debugPrint('InstructorGroupController._init error: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 
   // ── State ──────────────────────────────

--- a/frontend/lib/presentation/screens/details/group_detail_screen.dart
+++ b/frontend/lib/presentation/screens/details/group_detail_screen.dart
@@ -725,7 +725,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Text('#${group.serialNumber} ${group.name}', style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: AppColors.text)),
+                                  Text(group.name, style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: AppColors.text)),
                                   const SizedBox(height: 6),
                                   // Level badges
                                   Wrap(

--- a/frontend/lib/presentation/screens/instructor/groups_screen.dart
+++ b/frontend/lib/presentation/screens/instructor/groups_screen.dart
@@ -181,6 +181,31 @@ class _InstructorGroupsScreenState extends State<InstructorGroupsScreen> {
         if (_controller.isLoading) {
           return const Scaffold(body: Center(child: CircularProgressIndicator()));
         }
+        if (_controller.error != null) {
+          return Scaffold(
+            body: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.error_outline, color: Colors.red, size: 48),
+                    const SizedBox(height: 16),
+                    const Text('Failed to load groups', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                    const SizedBox(height: 8),
+                    Text(_controller.error!, style: const TextStyle(fontSize: 12, color: Colors.grey), textAlign: TextAlign.center),
+                    const SizedBox(height: 20),
+                    ElevatedButton(
+                      onPressed: () => _controller.refresh(),
+                      style: ElevatedButton.styleFrom(backgroundColor: AppColors.primary, foregroundColor: Colors.white),
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }
         final groups = _controller.myGroups;
 
         return Scaffold(

--- a/frontend/lib/presentation/widgets/group_card.dart
+++ b/frontend/lib/presentation/widgets/group_card.dart
@@ -51,7 +51,7 @@ class GroupCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '#$serialNumber $groupName',
+                        groupName,
                         style: const TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.bold,


### PR DESCRIPTION
- Fix FormatException: add _parseDate() helper in GroupModel to handle Firestore Timestamp
- Fix infinite loading: add try/catch/finally in InstructorGroupController._init()
- Fix groups not loading: remove orderBy() from Firestore queries to avoid missing composite index, sort in Dart instead
- Fix createGroup: use count().get()+1 for clean sequential serial numbers instead of millisecondsSinceEpoch
- Fix createStudent: write directly to Firestore instead of calling failing Cloud Function
- Fix addInstructor: write directly to Firestore instead of calling failing Cloud Function
- Fix addStudentToGroup: use batch.set() with merge instead of batch.update() for new student docs
- Fix groups screen: add error state with Retry button instead of infinite loading
- Remove cloud_functions import from user_repository (unused after bypass)
- Remove serial number display from GroupCard and GroupDetailScreen UI